### PR TITLE
create image: 'copy_from' option added

### DIFF
--- a/configs/sample-config.cfg
+++ b/configs/sample-config.cfg
@@ -31,6 +31,8 @@ file=/home/user/
 
 [[ IMAGES ]] # Can have as many images as need
 [[[ Debian-7.3 ]]] # Name here, below all valid image args for creation
+# Whether 'file' (uploaded from local file) or 'copy_from' (copied from URL) can be set
+# copy_from=http://www.change-me.org/debian-7.3.img
 file=/home/user/images/debian/debian-7.3.img
 disk_format=qcow2
 container_format=bare

--- a/setup_accounts.py
+++ b/setup_accounts.py
@@ -166,7 +166,8 @@ class AccountSetUp(object):
             image_info['name'] = image_name
             file_location = image_info.pop('file', None)
             new_image = glance.images.create(**image_info)
-            new_image.update(data=open(file_location,'rb'))
+            if file_location is not None:
+                new_image.update(data=open(file_location,'rb'))
 
 def parse_args():
     a = argparse.ArgumentParser(description='Setup accounts on an OpenStack cluster')


### PR DESCRIPTION
Hi Tyler

Here is the code I've added to provide glance images from local computer (file) or a copied image from an URL (copied_from). I did not add any exception handling if none of them (whether file nor copied_from) are configured.

Cheers,
Simon
